### PR TITLE
Add GCP vertex AI support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "Python 3.12 Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "features": {
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "3.12"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python"
+            },
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ]
+        }
+    },
+    "postCreateCommand": "pip install --upgrade pip"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+PROJECT_NAME := openai-access-gateway
+
+# VERSION is the version we should download and use.
+VERSION:=$(shell git rev-parse --short HEAD)
+# DOCKER is the docker image repo we need to push to.
+DOCKER_REPO:=defangio
+DOCKER_IMAGE_NAME:=$(DOCKER_REPO)/$(PROJECT_NAME)
+
+DOCKER_IMAGE_ARM64:=$(DOCKER_IMAGE_NAME):arm64-$(VERSION)
+DOCKER_IMAGE_AMD64:=$(DOCKER_IMAGE_NAME):amd64-$(VERSION)
+
+.PHONY: image-amd64
+image-amd64:
+	docker build --platform linux/amd64 -f ./src/Dockerfile_ecs -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_AMD64) --provenance false ./src
+
+.PHONY: image-arm64
+image-arm64:
+	docker build --platform linux/arm64 -f ./src/Dockerfile_ecs -t ${PROJECT_NAME} -t $(DOCKER_IMAGE_ARM64) --provenance false ./src
+
+.PHONY: images
+images: image-amd64 image-arm64 ## Build all docker images and manifest
+
+.PHONY: push-images
+push-images: images login ## Push all docker images
+	docker push $(DOCKER_IMAGE_AMD64)
+	docker push $(DOCKER_IMAGE_ARM64)
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
+	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
+	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
+
+.PHONY: login
+login: ## Login to docker
+	@docker login

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -13,57 +13,26 @@ from contextlib import asynccontextmanager
 from api.routers import chat, embeddings, model
 from api.setting import API_ROUTE_PREFIX, DESCRIPTION, SUMMARY, TITLE, VERSION
 
-METADATA_URL = "http://metadata.google.internal/computeMetadata/v1"
-HEADERS = {"Metadata-Flavor": "Google"}
-
-proxy_target: str | None = None  # Global, will be populated on startup
-
-async def get_project_id_and_region():
-    try:
-        project_id: str | None = None
-        region: str | None = None
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            # Get project ID
-            target_url = f"{METADATA_URL}/project/project-id"
-            project_id_resp = await client.get(target_url, headers=HEADERS)
-            project_id_resp.raise_for_status()
-            project_id = project_id_resp.text
-
-            # Get full region path
-            target_url = f"{METADATA_URL}/instance/region"
-            region_resp = await client.get(target_url, headers=HEADERS)
-            region_resp.raise_for_status()
-            region_full_path = region_resp.text
-
-        region = region_full_path.split("/")[-1]
-        return project_id, region
-
-    except httpx.HTTPError as e:
-        logging.error(f"Google metadata request failed: {e}")
-        return project_id, region
-    
-async def get_gcp_target():
+def get_gcp_target():
     """
     Check if the environment variable is set to use GCP.
     """
-
-    project_id, region = await get_project_id_and_region()
-    project_id = project_id if project_id else os.getenv("GCP_PROJECT_ID")
-    region = region if region else os.getenv("GCP_REGION")
+    project_id = os.getenv("GCP_PROJECT_ID")
+    region = os.getenv("GCP_REGION")
 
     if project_id and region:
         return f"https://{region}-aiplatform.googleapis.com/v1beta1/projects/{project_id}/locations/{region}/endpoints/openapi/"
 
     return None
 
-async def get_proxy_target():
+def get_proxy_target():
     """
     Check if the environment variable is set to use a proxy.
     """
     proxy_target = os.getenv("PROXY_TARGET")
     if proxy_target:
         return proxy_target
-    gcp_target = await get_gcp_target()
+    gcp_target = get_gcp_target()
     if gcp_target:
         return gcp_target
 
@@ -81,72 +50,19 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 
-
 async def setup_routing(app: FastAPI):
     """
     Setup routing for the application.
     This function is called during the lifespan of the application.
     """
-    if proxy_target:
-        logging.info(f"Proxy target set to: {proxy_target}")
-        @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
-        async def proxy(request: Request, path: str):
-            # Build safe target URL
-            path_no_prefix = f"/{path.lstrip('/')}".removeprefix(API_ROUTE_PREFIX)
-            target_url = f"{proxy_target.rstrip('/')}/{path_no_prefix.lstrip('/')}".rstrip("/")
 
-            # Sanitize headers
-            headers = {
-                k: v for k, v in request.headers.items()
-                if k.lower() not in {"host", "content-length", "accept-encoding", "connection"}
-            }
+proxy_target = get_proxy_target()
+if proxy_target:
+    logging.info(f"Proxy target set to: {proxy_target}")
+else:
+    logging.info("No proxy target set. Using internal routers.")
 
-            try:
-                async with httpx.AsyncClient() as client:
-                    response = await client.request(
-                        method=request.method,
-                        url=target_url,
-                        headers=headers,
-                        # TODO: can we avoid deserializing the body and re-serializing it?
-                        content=await request.body(),
-                        params=request.query_params,
-                        timeout=30.0,
-                    )
-            except httpx.RequestError as e:
-                logging.error(f"Proxy request failed: {e}")
-                return Response(status_code=502, content=f"Upstream request failed: {e}")
-
-            # filter out headers that could cause issues to client (because we act as a proxy)
-            response_headers = {
-                k: v for k, v in response.headers.items()
-                if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
-            }
-
-            return Response(
-                content=response.content,
-                status_code=response.status_code,
-                headers=response_headers,
-                media_type=response.headers.get("content-type", "application/octet-stream"),
-            )
-    else:
-        logging.info("No proxy target set. Using internal routers.")
-        app.include_router(model.router, prefix=API_ROUTE_PREFIX)
-        app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
-        app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    global proxy_target
-    proxy_target = await get_proxy_target()
-    if proxy_target:
-        logging.info(f"Proxy target set to: {proxy_target}")
-    else:
-        logging.info("No proxy target set. Using internal routers.")
-
-    await setup_routing(app)
-
-    yield  # After this point app will shutdown
-app = FastAPI(**config, lifespan=lifespan)
+app = FastAPI(**config)
 
 app.add_middleware(
     CORSMiddleware,
@@ -156,6 +72,52 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+if proxy_target:
+    logging.info(f"Proxy target set to: {proxy_target}")
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
+    async def proxy(request: Request, path: str):
+        # Build safe target URL
+        path_no_prefix = f"/{path.lstrip('/')}".removeprefix(API_ROUTE_PREFIX)
+        target_url = f"{proxy_target.rstrip('/')}/{path_no_prefix.lstrip('/')}".rstrip("/")
+
+        # Sanitize headers
+        headers = {
+            k: v for k, v in request.headers.items()
+            if k.lower() not in {"host", "content-length", "accept-encoding", "connection"}
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.request(
+                    method=request.method,
+                    url=target_url,
+                    headers=headers,
+                    # TODO: can we avoid deserializing the body and re-serializing it?
+                    content=await request.body(),
+                    params=request.query_params,
+                    timeout=30.0,
+                )
+        except httpx.RequestError as e:
+            logging.error(f"Proxy request failed: {e}")
+            return Response(status_code=502, content=f"Upstream request failed: {e}")
+
+        # filter out headers that could cause issues to client (because we act as a proxy)
+        response_headers = {
+            k: v for k, v in response.headers.items()
+            if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+        }
+
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=response_headers,
+            media_type=response.headers.get("content-type", "application/octet-stream"),
+        )
+else:
+    logging.info("No proxy target set. Using internal routers.")
+    app.include_router(model.router, prefix=API_ROUTE_PREFIX)
+    app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
+    app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
 
 @app.get("/health")
 async def health():

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -74,7 +74,7 @@ if proxy_target:
         path_no_prefix = f"/{path.lstrip('/')}".removeprefix(API_ROUTE_PREFIX)
         target_url = f"{proxy_target.rstrip('/')}/{path_no_prefix.lstrip('/')}".rstrip("/")
 
-        # Sanitize headers
+        # remove hop-by-hop headers
         headers = {
             k: v for k, v in request.headers.items()
             if k.lower() not in {"host", "content-length", "accept-encoding", "connection"}
@@ -95,7 +95,7 @@ if proxy_target:
             logging.error(f"Proxy request failed: {e}")
             return Response(status_code=502, content=f"Upstream request failed: {e}")
 
-        # filter out headers that could cause issues to client (because we act as a proxy)
+        # remove hop-by-hop headers
         response_headers = {
             k: v for k, v in response.headers.items()
             if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -8,38 +8,46 @@ from fastapi.responses import PlainTextResponse
 from mangum import Mangum
 import httpx
 import os
+from contextlib import asynccontextmanager
 
 from api.routers import chat, embeddings, model
 from api.setting import API_ROUTE_PREFIX, DESCRIPTION, SUMMARY, TITLE, VERSION
 
-METADATA_URL = "http:///metadata.google.internal/computeMetadata/v1"
+METADATA_URL = "http://metadata.google.internal/computeMetadata/v1"
 HEADERS = {"Metadata-Flavor": "Google"}
 
-async def get_project_id_and_region():
+proxy_target: str | None = None  # Global, will be populated on startup
+
+async def get_project_id_and_location():
     try:
+        project_id: str | None = None
+        location: str | None = None
         async with httpx.AsyncClient(timeout=2.0) as client:
             # Get project ID
-            project_id_resp = await client.get(f"{METADATA_URL}/project/project-id", headers=HEADERS)
+            target_url = f"{METADATA_URL}/project/project-id"
+            project_id_resp = await client.get(target_url, headers=HEADERS)
             project_id_resp.raise_for_status()
             project_id = project_id_resp.text
 
             # Get full region path
-            region_resp = await client.get(f"{METADATA_URL}/instance/region", headers=HEADERS)
-            region_resp.raise_for_status()
-            full_region = region_resp.text
+            target_url = f"{METADATA_URL}/instance/region"
+            location_resp = await client.get(target_url, headers=HEADERS)
+            location_resp.raise_for_status()
+            full_location = location_resp.text
 
-        region = full_region.split("/")[-1]
-        return project_id, region
+        location = full_location.split("/")[-1]
+        return project_id, location
 
     except httpx.HTTPError as e:
-        return None, None
+        logging.error(f"Google metadata request failed: {e}")
+        return project_id, location
     
-def get_gcp_target():
+async def get_gcp_target():
     """
     Check if the environment variable is set to use GCP.
     """
 
-    project_id, location = get_project_id_and_region()
+    project_id, location = await get_project_id_and_location()
     project_id = project_id if project_id else os.getenv("GCP_PROJECT_ID")
     location = location if location else os.getenv("GCP_LOCATION")
 
@@ -48,14 +56,14 @@ def get_gcp_target():
 
     return None
 
-def get_proxy_target():
+async def get_proxy_target():
     """
     Check if the environment variable is set to use a proxy.
     """
     proxy_target = os.getenv("PROXY_TARGET")
     if proxy_target:
         return proxy_target
-    gcp_target = get_gcp_target()
+    gcp_target = await get_gcp_target()
     if gcp_target:
         return gcp_target
 
@@ -72,7 +80,70 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
-app = FastAPI(**config)
+
+
+async def setup_routing(app: FastAPI):
+    """
+    Setup routing for the application.
+    This function is called during the lifespan of the application.
+    """
+    if proxy_target:
+        @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
+        async def proxy(request: Request, path: str):
+            # Build safe target URL
+            path_no_prefix = f"/{path.lstrip('/')}".removeprefix(API_ROUTE_PREFIX)
+            target_url = f"{proxy_target.rstrip('/')}/{path_no_prefix.lstrip('/')}".rstrip("/")
+
+            # Sanitize headers
+            headers = {
+                k: v for k, v in request.headers.items()
+                if k.lower() not in {"host", "content-length", "accept-encoding", "connection"}
+            }
+
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.request(
+                        method=request.method,
+                        url=target_url,
+                        headers=headers,
+                        # TODO: can we avoid deserializing the body and re-serializing it?
+                        content=await request.body(),
+                        params=request.query_params,
+                        timeout=30.0,
+                    )
+            except httpx.RequestError as e:
+                logging.error(f"Proxy request failed: {e}")
+                return Response(status_code=502, content=f"Upstream request failed: {e}")
+
+            # filter out headers that could cause issues to client (because we act as a proxy)
+            response_headers = {
+                k: v for k, v in response.headers.items()
+                if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+            }
+            return Response(
+                content=response.content,
+                status_code=response.status_code,
+                headers=response_headers,
+                media_type=response.headers.get("content-type", "application/octet-stream"),
+            )
+    else:
+        app.include_router(model.router, prefix=API_ROUTE_PREFIX)
+        app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
+        app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global proxy_target
+    proxy_target = await get_proxy_target()
+    if proxy_target:
+        logging.info(f"Proxy target set to: {proxy_target}")
+    else:
+        logging.info("No proxy target set. Using internal routers.")
+
+    await setup_routing(app)
+
+    yield  # After this point app will shutdown
+app = FastAPI(**config, lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -81,52 +152,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-proxy_target = get_proxy_target()
-
-if proxy_target:
-    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
-    async def proxy(request: Request, path: str):
-        # Build safe target URL
-        target_url = f"{proxy_target.rstrip('/')}/{path.lstrip('/')}".rstrip("/")
-
-        # Sanitize headers
-        headers = {
-            k: v for k, v in request.headers.items()
-            if k.lower() not in {"host", "content-length", "accept-encoding"}
-        }
-
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.request(
-                    method=request.method,
-                    url=target_url,
-                    headers=headers,
-                    # TODO: can we avoid deserializing the body and re-serializing it?
-                    content=await request.body(),
-                    params=request.query_params,
-                    timeout=30.0,
-                )
-        except httpx.RequestError as e:
-            logging.error(f"Proxy request failed: {e}")
-            return Response(status_code=502, content=f"Upstream request failed: {e}")
-
-        # filter out headers that could cause issues to client (because we act as a proxy)
-        response_headers = {
-            k: v for k, v in response.headers.items()
-            if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
-        }
-        return Response(
-            content=response.content,
-            status_code=response.status_code,
-            headers=response_headers,
-            media_type=response.headers.get("content-type", "application/octet-stream"),
-        )
-    
-else:
-    app.include_router(model.router, prefix=API_ROUTE_PREFIX)
-    app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
-    app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
 
 
 @app.get("/health")

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -88,6 +88,7 @@ async def setup_routing(app: FastAPI):
     This function is called during the lifespan of the application.
     """
     if proxy_target:
+        logging.info(f"Proxy target set to: {proxy_target}")
         @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
         async def proxy(request: Request, path: str):
             # Build safe target URL
@@ -120,6 +121,7 @@ async def setup_routing(app: FastAPI):
                 k: v for k, v in response.headers.items()
                 if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
             }
+
             return Response(
                 content=response.content,
                 status_code=response.status_code,
@@ -127,6 +129,7 @@ async def setup_routing(app: FastAPI):
                 media_type=response.headers.get("content-type", "application/octet-stream"),
             )
     else:
+        logging.info("No proxy target set. Using internal routers.")
         app.include_router(model.router, prefix=API_ROUTE_PREFIX)
         app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
         app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -50,12 +50,6 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 
-async def setup_routing(app: FastAPI):
-    """
-    Setup routing for the application.
-    This function is called during the lifespan of the application.
-    """
-
 proxy_target = get_proxy_target()
 if proxy_target:
     logging.info(f"Proxy target set to: {proxy_target}")

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -23,7 +23,7 @@ def get_gcp_target():
     location = os.getenv("GCP_REGION")
 
     if project_id and location:
-        return f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project_id}/locations/{location}/endpoints/openapi/chat/completions"
+        return f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project_id}/locations/{location}/endpoints/openapi/"
 
     return None
 
@@ -106,10 +106,15 @@ if proxy_target:
             logging.error(f"Proxy request failed: {e}")
             return Response(status_code=502, content=f"Upstream request failed: {e}")
 
+        # filter out headers that could cause issues to client (because we act as a proxy)
+        response_headers = {
+            k: v for k, v in response.headers.items()
+            if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+        }
         return Response(
             content=response.content,
             status_code=response.status_code,
-            headers=dict(response.headers),
+            headers=response_headers,
             media_type=response.headers.get("content-type", "application/octet-stream"),
         )
     

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,7 +1,7 @@
 import logging
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
@@ -18,12 +18,12 @@ def get_gcp_target():
     """
 
     # TODO: are these the best env vars to check for?
-    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    project_id = os.getenv("GCP_PROJECT_ID")
     project_id = project_id if project_id else os.getenv("GCLOUD_PROJECT")
-    location = os.getenv("CLOUDSDK_COMPUTE_REGION")
+    location = os.getenv("GCP_REGION")
 
     if project_id and location:
-        return f"https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/endpoints/openapi",
+        return f"https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project_id}/locations/{location}/endpoints/openapi/chat/completions"
 
     return None
 
@@ -83,22 +83,93 @@ if proxy_target:
     @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
     async def proxy(request: Request, path: str):
         async with httpx.AsyncClient() as client:
-            # Build the target URL
-            target_url = f"{proxy_target}/{path}"
+            # Read body only once
+            body = await request.body()
 
-            # Forward the request
-            response = await client.request(
-                method=request.method,
-                url=target_url,
-                headers=request.headers.raw,
-                # TODO: can we avoid deserializing the body and re-serializing it?
-                content=await request.body(),
-                params=request.query_params,
-            )
+        # Build safe target URL
+        target_url = proxy_target.rstrip('/')
+        if path:
+            target_url += '/' + path.lstrip('/')
 
-            # TODO: can we avoid deserializing the response body and re-serializing it?
-            # Return the response with the same status code and headers
-            return response.json(), response.status_code, dict(response.headers)
+        logging.info(f"Forwarding request to: {target_url}")
+        logging.info(f"Request method: {request.method}")
+        logging.info(f"Incoming path: {request.url.path}")
+        logging.info(f"Request body:\n{body.decode('utf-8', errors='replace')}")
+
+        # Sanitize headers
+        headers = {
+            k: v for k, v in request.headers.items()
+            if k.lower() not in {"host", "content-length", "accept-encoding"}
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.request(
+                    method=request.method,
+                    url=target_url,
+                    headers=headers,
+                    content=body,
+                    params=dict(request.query_params),
+                    timeout=30.0,
+                )
+        except httpx.RequestError as e:
+            logging.error(f"Proxy request failed: {e}")
+            return Response(status_code=502, content=f"Upstream request failed: {e}")
+
+        logging.info(f"Upstream responded with {response.status_code}")
+
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            media_type=response.headers.get("content-type", "application/octet-stream"),
+        )            
+            # # Build the target URL
+            # target_url = f"{proxy_target}/{path}".rstrip("/")
+
+            # body = await request.body()
+
+            # # Print or log the request body
+            # logging.info(f"Forwarding request to: {target_url}")
+            # logging.info(f"Request method: {request.method}")
+            # logging.info(f"Request body:\n{body.decode('utf-8', errors='replace')}")
+
+
+            # logging.info(f"Incoming path: {request.url.path}")
+            # # Forward the request
+            # resp = await client.request(
+            #     method=request.method,
+            #     url=target_url,
+            #     headers=request.headers.raw,
+            #     # TODO: can we avoid deserializing the body and re-serializing it?
+            #     content=body,
+            #     params=request.query_params,
+            # )
+
+            # # async with httpx.AsyncClient() as client:
+            # #     try:
+            # #         resp = await client.request(
+            # #             method=request.method,
+            # #             url=target_url,
+            # #             headers={k: v for k, v in request.headers.items() if k.lower() != "host"},
+            # #             content=body,
+            # #             params=request.query_params,
+            # #         )
+            # #     except httpx.RequestError as e:
+            # #         logging.error(f"Proxy request failed: {e}")
+            # #         return Response(status_code=502, content=f"Upstream request failed: {e}")
+
+
+            # # TODO: can we avoid deserializing the response body and re-serializing it?
+            # # Return the response with the same status code and headers
+            # # return response.json(), response.status_code, dict(response.headers)
+    
+            # return Response(
+            #     content=resp.content,
+            #     status_code=resp.status_code,
+            #     headers=dict(resp.headers),
+            #     media_type=resp.headers.get("content-type", "application/octet-stream"),
+            # )
 
 else:
     app.include_router(model.router, prefix=API_ROUTE_PREFIX)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -106,8 +106,6 @@ if proxy_target:
             logging.error(f"Proxy request failed: {e}")
             return Response(status_code=502, content=f"Upstream request failed: {e}")
 
-        logging.info(f"Upstream responded with {response.status_code}")
-
         return Response(
             content=response.content,
             status_code=response.status_code,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,3 +7,4 @@ requests==2.32.3
 numpy==1.26.4
 boto3==1.37.0
 botocore==1.37.0
+httpx==0.24.1


### PR DESCRIPTION
*Issue #, if available:*
[#1700](https://github.com/DefangLabs/defang-mvp/issues/1700)

*Description of changes:*
Add supporting changes to allow GCP vertex REST calls to be proxied through this services and delivered to the proper GCP AI endpoint. 

- update endpoint URL for GCP for vertex model support
- updates to proxy_target to include only expected headers and a timeout.
- Response handling for non-json (often HTML for errors) messages. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
