### PR TITLE
Add GCP authentication on proxy

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -17,7 +17,7 @@ from google.auth import default
 from google.auth.transport.requests import Request as AuthRequest
 
 # Utility: get service account access token
-async def get_access_token():
+def get_access_token():
     credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
     auth_request = AuthRequest()
     credentials.refresh(auth_request)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,3 +8,4 @@ numpy==1.26.4
 boto3==1.37.0
 botocore==1.37.0
 httpx==0.24.1
+google-auth==2.22.0


### PR DESCRIPTION
*Description of changes:*
Overrides client authentication with service account authentication so clients do not need service account authentication themselves to use the AI service. This override happens for every gcp proxy message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
