### PR TITLE
Make auth optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,15 @@ push-images: images login ## Push all docker images
 	docker push $(DOCKER_IMAGE_AMD64)
 	docker push $(DOCKER_IMAGE_ARM64)
 	docker manifest create --amend $(DOCKER_IMAGE_NAME):$(VERSION) $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
-	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):$(VERSION)
+
+.PHONY: no-diff
+no-diff:
+	git diff-index --quiet HEAD --       # check that there are no uncommitted changes
+
+.PHONY: push
+push: no-diff push-images ## Push all docker images and "latest" manifest
+	docker manifest create --amend $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_AMD64) $(DOCKER_IMAGE_ARM64)
 	docker manifest push --purge $(DOCKER_IMAGE_NAME):latest
 
 .PHONY: login

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -34,11 +34,11 @@ else:
     # For local use only.
     api_key = DEFAULT_API_KEYS
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 def api_key_auth(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    authorization: Annotated[HTTPAuthorizationCredentials, Depends(security)],
 ):
-    if credentials.credentials != api_key:
+    if authorization.credentials != api_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key")

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -28,17 +28,17 @@ elif api_key_secret_arn:
         raise RuntimeError("Unable to retrieve API KEY, please ensure the secret ARN is correct")
     except KeyError:
         raise RuntimeError('Please ensure the secret contains a "api_key" field')
-elif api_key_env:
+elif api_key_env != None:
     api_key = api_key_env
 else:
     # For local use only.
     api_key = DEFAULT_API_KEYS
 
-security = HTTPBearer(auto_error=False)
+security = HTTPBearer(auto_error=api_key != "")
 
 
 def api_key_auth(
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(security)],
 ):
-    if authorization.credentials != api_key:
+    if authorization and authorization.credentials != api_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key")


### PR DESCRIPTION
*Description of changes:*

Make auth header optional, only when the `OPENAI_API_KEY` is explicitly set to the empty string. This allows us to use the gateway for projects that use the Docker Model Runner locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
