### PR TITLE
add model mapping for embeddings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ push: no-diff login
 .PHONY: login
 login: ## Login to docker
 	@docker login
+
+.PHONY: tests
+tests:
+	PYTHONPATH=src pytest

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -10,7 +10,7 @@ from mangum import Mangum
 
 from api.setting import API_ROUTE_PREFIX, DESCRIPTION, SUMMARY, PROVIDER, TITLE, USE_MODEL_MAPPING, VERSION
 from api.modelmapper import load_model_map
-from api.routers.vertex import handle_proxy
+from api.routers.gcp.chat import handle_proxy
 
 def is_aws():
     env = os.getenv("AWS_EXECUTION_ENV")
@@ -54,10 +54,10 @@ app.add_middleware(
 )
 
 if provider != "aws":
+    from api.routers.gcp import chat, embeddings
     logging.info(f"Proxy target set to: GCP")
-    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"])
-    async def proxy(request: Request, path: str):
-        return await handle_proxy(request, path)
+    app.include_router(chat.router, prefix=API_ROUTE_PREFIX)
+    app.include_router(embeddings.router, prefix=API_ROUTE_PREFIX)
 else:
     from api.routers import chat, embeddings, model
     logging.info("No proxy target set. Using internal routers.")

--- a/src/api/gcp/credentials/metadata.py
+++ b/src/api/gcp/credentials/metadata.py
@@ -1,0 +1,48 @@
+import logging
+import requests
+
+from google.auth import default
+from google.auth.transport.requests import Request as AuthRequest
+
+from api.setting import GCP_PROJECT_ID, GCP_REGION
+
+
+# GCP credentials and project details
+credentials = None
+project_id = None
+location = None
+
+def get_gcp_project_details():
+    from google.auth import default
+
+    # Try metadata server for region
+    credentials = None
+    project_id = GCP_PROJECT_ID
+    location = GCP_REGION
+
+    try:
+        credentials, project = default()
+        if not project_id:
+            project_id = project
+
+        if not location:
+            zone = requests.get(
+                "http://metadata.google.internal/computeMetadata/v1/instance/zone",
+                headers={"Metadata-Flavor": "Google"},
+                timeout=1
+            ).text
+            location = zone.split("/")[-1].rsplit("-", 1)[0]
+
+    except Exception:
+        logging.warning(f"Error: Failed to get project and location from metadata server. Using local settings.")
+
+    return credentials, project_id, location
+
+credentials, project_id, location = get_gcp_project_details()
+
+# Utility: get service account access token
+def get_access_token():
+    credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    auth_request = AuthRequest()
+    credentials.refresh(auth_request)
+    return credentials.token

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -39,6 +39,7 @@ from api.schema import (
     UserMessage,
 )
 from api.setting import AWS_REGION, DEBUG, DEFAULT_MODEL, ENABLE_CROSS_REGION_INFERENCE
+from modelmapper import get_model
 
 logger = logging.getLogger(__name__)
 
@@ -868,6 +869,7 @@ class TitanEmbeddingsModel(BedrockEmbeddingsModel):
 
 
 def get_embeddings_model(model_id: str) -> BedrockEmbeddingsModel:
+    model_id = get_model("aws", model_id)
     model_name = SUPPORTED_BEDROCK_EMBEDDING_MODELS.get(model_id, "")
     if DEBUG:
         logger.info("model name is " + model_name)

--- a/src/api/routers/gcp/chat.py
+++ b/src/api/routers/gcp/chat.py
@@ -32,7 +32,7 @@ known_chat_models = [
 ]
 
 router = APIRouter(
-    prefix="/embeddings",
+    prefix="/chat",
     dependencies=[Depends(api_key_auth)],
 )
 

--- a/src/api/routers/gcp/chat.py
+++ b/src/api/routers/gcp/chat.py
@@ -47,7 +47,7 @@ def get_proxy_target(model, path):
     else:
         return f"https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/{model}:rawPredict"
 
-def get_header(model, request, path):
+def get_headers(model, request, path):
     path_no_prefix = f"/{path.lstrip('/')}".removeprefix(API_ROUTE_PREFIX)
     target_url = get_proxy_target(model, path_no_prefix)
 
@@ -127,7 +127,7 @@ async def handle_proxy(request: Request, path: str):
                 conversion_target = "anthropic"
 
         # Build safe target URL
-        target_url, request_headers = get_header(model, request, path)
+        target_url, request_headers = get_headers(model, request, path)
         async with httpx.AsyncClient() as client:
             response = await client.request(
                 method=request.method,

--- a/src/api/routers/gcp/embeddings.py
+++ b/src/api/routers/gcp/embeddings.py
@@ -1,0 +1,82 @@
+import httpx
+import json
+import logging
+import os
+
+from fastapi import APIRouter, Body, Depends, Request, Response
+from contextlib import asynccontextmanager
+from api.auth import api_key_auth
+from api.schema import EmbeddingsResponse
+from api.setting import API_ROUTE_PREFIX
+from google.auth import default
+from google.auth.transport.requests import Request as AuthRequest
+
+from api.modelmapper import get_model
+from api.gcp.credentials.metadata import get_access_token, project_id, location
+
+router = APIRouter(
+    prefix="/embeddings",
+    dependencies=[Depends(api_key_auth)],
+)
+def get_proxy_target(model, path):
+    """
+    Check if the environment variable is set to use GCP.
+    """
+    if os.getenv("PROXY_TARGET"):
+        return os.getenv("PROXY_TARGET")
+    elif path.endswith("/embeddings"):
+        return f"https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/{model}:predict"
+
+def get_header(model, request, path):
+    path_no_prefix = f"/{path.lstrip('/')}".removeprefix(API_ROUTE_PREFIX)
+    target_url = get_proxy_target(model, path_no_prefix)
+
+    # remove hop-by-hop headers
+    headers = {
+        k: v for k, v in request.headers.items()
+        if k.lower() not in {"host", "content-length", "accept-encoding", "connection", "authorization"}
+    }
+
+    # Fetch service account token
+    access_token = get_access_token()
+    headers["Authorization"] = f"Bearer {access_token}"
+    return target_url, headers
+
+@router.post("", response_model=EmbeddingsResponse)
+async def handle_proxy(request: Request, path: str):
+    try:
+        content = await request.body()
+        content_json = json.loads(content)
+        model_alias = content_json.get("model", "default")
+        model = get_model("gcp", model_alias)
+
+        # Build safe target URL
+        target_url, request_headers = get_header(model, request, path)
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method=request.method,
+                url=target_url,
+                headers=request_headers,
+                content=json.dumps(content_json),
+                params=request.query_params,
+                timeout=5.0,
+            )
+
+        content = response.content
+
+    except httpx.RequestError as e:
+        logging.error(f"Proxy request failed: {e}")
+        return Response(status_code=502, content=f"Upstream request failed: {e}")
+
+    # remove hop-by-hop headers
+    response_headers = {
+        k: v for k, v in response.headers.items()
+        if k.lower() not in {"content-encoding", "transfer-encoding", "connection"}
+    }
+
+    return Response(
+        content=content,
+        status_code=response.status_code,
+        headers=response_headers,
+        media_type=response.headers.get("content-type", "application/octet-stream"),
+    )

--- a/src/api/routers/gcp/embeddings.py
+++ b/src/api/routers/gcp/embeddings.py
@@ -5,7 +5,7 @@ import os
 
 from fastapi import APIRouter, Depends, Request, Response
 from api.auth import api_key_auth
-from api.schema import EmbeddingsRequest, EmbeddingsResponse
+from api.schema import EmbeddingsResponse
 from api.setting import API_ROUTE_PREFIX
 
 from api.modelmapper import get_model
@@ -77,7 +77,7 @@ def to_openai_response(embedding_content, model):
         "model": model,
         "object": "list",
         "usage": {
-            "total_tokens": total_tokens,
+            "total_tokens": total_tokens
         }
     }
 

--- a/src/api/routers/gcp/embeddings.py
+++ b/src/api/routers/gcp/embeddings.py
@@ -61,6 +61,11 @@ def to_openai_response(embedding_content, model):
     """
     Convert Vertex AI embeddings response to OpenAI format.
     """
+    total_tokens = sum(
+        item["embeddings"]["statistics"]["token_count"]
+        for item in embedding_content.get("predictions", [])
+    )
+
     return {
         "data": [
             {
@@ -70,7 +75,10 @@ def to_openai_response(embedding_content, model):
             } for idx, item in enumerate(embedding_content.get("predictions", []))
         ],
         "model": model,
-        "object": "list"
+        "object": "list",
+        "usage": {
+            "total_tokens": total_tokens,
+        }
     }
 
 @router.post("/{path:path}", response_model=EmbeddingsResponse)

--- a/src/api/routers/gcp/embeddings.py
+++ b/src/api/routers/gcp/embeddings.py
@@ -43,19 +43,12 @@ def to_vertex_embeddings(request):
     """
     Convert OpenAI-style embeddings request to Vertex AI format.
     """
-    vertex_request = {
-        "instances": []
+    inputs = request.get("input", [])
+    if not isinstance(inputs, list):
+        inputs = [inputs]
+    return {
+        "instances": [{"content": str(content)} for content in inputs]
     }
-
-    msg_input = request.get("input")
-    if type(msg_input) is str:
-        vertex_request["instances"] = [{
-            "content": f"{msg_input}"
-            }]
-    elif type(msg_input) is list:
-        vertex_request["instances"] = [{"content": f"{str(item)}"} for item in msg_input]
-
-    return vertex_request
 
 def to_openai_response(embedding_content, model):
     """

--- a/src/api/routers/gcp/test_embeddings.py
+++ b/src/api/routers/gcp/test_embeddings.py
@@ -1,0 +1,138 @@
+import pytest
+from api.routers.gcp.embeddings import to_vertex_embeddings
+import json
+from unittest.mock import patch, AsyncMock, MagicMock
+import httpx
+from fastapi import Response, Request
+from starlette.datastructures import Headers, QueryParams
+from api.routers.gcp.embeddings import to_openai_response
+
+def test_to_vertex_embeddings_with_string_input():
+    request = {"input": "hello world"}
+    expected = {
+        "instances": [
+            {"content": "hello world"}
+        ]
+    }
+    assert to_vertex_embeddings(request) == expected
+
+def test_to_vertex_embeddings_with_list_of_strings():
+    request = {"input": ["foo", "bar"]}
+    expected = {
+        "instances": [
+            {"content": "foo"},
+            {"content": "bar"}
+        ]
+    }
+    assert to_vertex_embeddings(request) == expected
+
+def test_to_vertex_embeddings_with_list_of_numbers():
+    request = {"input": [1, 2, 3]}
+    expected = {
+        "instances": [
+            {"content": "1"},
+            {"content": "2"},
+            {"content": "3"}
+        ]
+    }
+    assert to_vertex_embeddings(request) == expected
+
+def test_to_vertex_embeddings_with_empty_list():
+    request = {"input": []}
+    expected = {
+        "instances": []
+    }
+    assert to_vertex_embeddings(request) == expected
+
+def test_to_vertex_embeddings_with_missing_input_key():
+    request = {}
+    expected = {
+        "instances": []
+    }
+    assert to_vertex_embeddings(request) == expected
+
+def test_to_openai_response_with_multiple_predictions():
+    embedding_content = {
+        "predictions": [
+            {"embeddings": {"values": [0.1, 0.2, 0.3], "statistics": {"token_count": 10}}},
+            {"embeddings": {"values": [0.4, 0.5, 0.6], "statistics": {"token_count": 20}}}
+        ]
+    }
+    model = "test-model"
+    expected = {
+        "data": [
+            {"embedding": [0.1, 0.2, 0.3], "index": 0, "object": "embedding"},
+            {"embedding": [0.4, 0.5, 0.6], "index": 1, "object": "embedding"}
+        ],
+        "model": "test-model",
+        "object": "list",
+        "usage": {
+            "total_tokens": 30
+        }
+    }
+    assert to_openai_response(embedding_content, model) == expected
+
+def test_to_openai_response_with_empty_predictions():
+    embedding_content = {
+        "predictions": []
+    }
+    model = "empty-model"
+    expected = {
+        "data": [],
+        "model": "empty-model",
+        "object": "list",
+        "usage": {
+            "total_tokens": 0
+        }
+    }
+    assert to_openai_response(embedding_content, model) == expected
+
+def test_to_openai_response_with_missing_predictions_key():
+    embedding_content = {}
+    model = "default-model"
+    expected = {
+        "data": [],
+        "model": "default-model",
+        "object": "list",
+        "usage": {
+            "total_tokens": 0
+        }
+    }
+    assert to_openai_response(embedding_content, model) == expected
+
+def test_to_openai_response_with_single_prediction():
+    embedding_content = {
+        "predictions": [
+            {
+                "embeddings": {
+                    "values": [1.0, 2.0, 3.0], "statistics": {"token_count": 5}
+                }
+            }
+        ]
+    }
+    model = "single-model"
+    expected = {
+        "data": [
+            {"embedding": [1.0, 2.0, 3.0], "index": 0, "object": "embedding"}
+        ],
+        "model": "single-model",
+        "object": "list",
+        "usage": {
+            "total_tokens": 5
+        }
+    }
+    assert to_openai_response(embedding_content, model) == expected
+
+def test_to_openai_response_with_nonstandard_embedding_key():
+    # This should raise a KeyError if "embeddings" or "values" is missing
+    embedding_content = {
+        "predictions": [
+            {"not_embeddings": {"values": [1, 2, 3]}}
+        ]
+    }
+    model = "bad-model"
+    try:
+        to_openai_response(embedding_content, model)
+        assert False, "Expected KeyError"
+    except KeyError:
+        pass

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -16,7 +16,7 @@ USE_MODEL_MAPPING = os.getenv("USE_MODEL_MAPPING", "true").lower() != "false"
 
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
-DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")
+DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "embeddings-default")
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
 
 GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID")

--- a/src/data/modelmap.json
+++ b/src/data/modelmap.json
@@ -29,6 +29,7 @@
     "nova-micro": "us.amazon.nova-micro-v1:0",
     "nova-premier-v1": "amazon.nova-premier-v1:0",
     "nova-pro": "us.amazon.nova-pro-v1:0",
+    "embedding-default": "amazon.titan-embed-text-v2:0",
     "default": "us.amazon.nova-micro-v1:0"
   },
   "gcp": {

--- a/src/data/modelmap.json
+++ b/src/data/modelmap.json
@@ -30,6 +30,7 @@
     "nova-premier-v1": "amazon.nova-premier-v1:0",
     "nova-pro": "us.amazon.nova-pro-v1:0",
     "embedding-default": "amazon.titan-embed-text-v2:0",
+    "chat-default": "us.amazon.nova-micro-v1:0",
     "default": "us.amazon.nova-micro-v1:0"
   },
   "gcp": {
@@ -62,6 +63,8 @@
     "gemini-2.0-flash-lite": "publishers/google/models/gemini-2.0-flash-lite-001",
     "gemini-2.5-flash": "publishers/google/models/gemini-2.5-flash-preview-05-20",
     "gemini-2.5-pro": "publishers/google/models/gemini-2.5-pro-preview-05-06",
+    "chat-default": "publishers/google/models/gemini-2.0-flash-lite-001",
+    "embedding-default": "publishers/google/models/text-embedding-005",
     "default": "publishers/google/models/gemini-2.0-flash-lite-001"
   }
 }


### PR DESCRIPTION
*Description of changes:*
Add GCP embeddings. Converts OpenAI embeddings request to a vertex embeddings to make call to model. Response is conversely converted from vertex response to OpenAI embeddings response.

The previous vertex.py was changed to chat.py (parallels how AWS does it). Minimal changes to AWS code to ensure we don't have major issues taking upstream changes.