### PR TITLE
make model optional in request

### DIFF
--- a/src/api/modelmapper.py
+++ b/src/api/modelmapper.py
@@ -11,8 +11,10 @@ def load_model_map():
     with open(modelmap_path, "r") as f:
         _model_map = json.load(f)
 
-def get_model(provider, model):
+def get_model(provider, model, fallback_model):
     provider = provider.lower()
+    if model is None or model == "":
+        model = fallback_model
     model = model.lower().removesuffix(":latest")
 
     available_models = _model_map.get(provider, {})

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -869,7 +869,7 @@ class TitanEmbeddingsModel(BedrockEmbeddingsModel):
 
 
 def get_embeddings_model(model_id: str) -> BedrockEmbeddingsModel:
-    model_id = get_model("aws", model_id)
+    model_id = get_model("aws", model_id, "embedding-default")
     model_name = SUPPORTED_BEDROCK_EMBEDDING_MODELS.get(model_id, "")
     if DEBUG:
         logger.info("model name is " + model_name)

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -36,13 +36,13 @@ async def chat_completions(
         ),
     ],
 ):
-    if chat_request.model.lower().startswith("gpt-"):
+    if chat_request.model != None and chat_request.model.lower().startswith("gpt-"):
         chat_request.model = DEFAULT_MODEL
 
     # replace with mapped model name 
     if USE_MODEL_MAPPING:
         req_model = chat_request.model
-        req_model = get_model("aws", req_model)
+        req_model = get_model("aws", req_model, "chat-default")
         chat_request.model = req_model
 
     model = BedrockModel()

--- a/src/api/routers/embeddings.py
+++ b/src/api/routers/embeddings.py
@@ -28,9 +28,9 @@ async def embeddings(
         ),
     ],
 ):
-    if embeddings_request.model.lower().startswith("text-embedding-"):
+    if embeddings_request.model != None and embeddings_request.model.lower().startswith("text-embedding-"):
         embeddings_request.model = DEFAULT_EMBEDDING_MODEL
     # Exception will be raised if model not supported.
-    embeddings_request.model = get_model("aws", embeddings_request.model)
+    embeddings_request.model = get_model("aws", embeddings_request.model, "embedding-default")
     model = get_embeddings_model(embeddings_request.model)
     return model.embed(embeddings_request)

--- a/src/api/routers/gcp/chat.py
+++ b/src/api/routers/gcp/chat.py
@@ -24,7 +24,7 @@ known_chat_models = [
     "publishers/mistral-ai/models/mistral-7b-instruct@v0.3",
     "publishers/google/models/gemma-2-27b-it",
     "publishers/google/models/gemma-2-9b-it",
-    "publishers/google/models/gemma-2b"
+    "publishers/google/models/gemma-2b",
     "publishers/google/models/gemini-2.0-flash-001",
     "publishers/google/models/gemini-2.0-flash-lite-001",
     "publishers/google/models/gemini-2.5-pro-preview-05-06",
@@ -189,15 +189,14 @@ async def handle_proxy(request: Request):
         content = await request.body()
         content_json = json.loads(content)
         is_streaming = content_json.get("stream", False)
-        model_alias = content_json.get("model", "default")
-        model = get_model("gcp", model_alias)
+        model_alias = content_json.get("model", "chat-default")
+        model = get_model("gcp", model_alias, "chat-default")
 
         if USE_MODEL_MAPPING:
-            if "model" in content_json:
-                content_json["model"] = get_chat_completion_model_name(model)
+            content_json["model"] = get_chat_completion_model_name(model)
 
         conversion_target = None
-        if not model in known_chat_models:
+        if model not in known_chat_models:
             # openai messages to vertex contents
             if "anthropic" in model:
                 content_json = to_vertex_anthropic(content_json)

--- a/src/api/routers/gcp/embeddings.py
+++ b/src/api/routers/gcp/embeddings.py
@@ -80,7 +80,7 @@ async def handle_proxy(request: Request, path: str):
         content = await request.body()
         content_json = json.loads(content)
         model_alias = content_json.get("model", "embedding-default")
-        model = get_model("gcp", model_alias)
+        model = get_model("gcp", model_alias, "embedding-default")
 
         # Build safe target URL
         target_url, request_headers = get_header(model, request, path)

--- a/src/api/routers/gcp/test_embeddings.py
+++ b/src/api/routers/gcp/test_embeddings.py
@@ -1,10 +1,4 @@
-import pytest
 from api.routers.gcp.embeddings import to_vertex_embeddings
-import json
-from unittest.mock import patch, AsyncMock, MagicMock
-import httpx
-from fastapi import Response, Request
-from starlette.datastructures import Headers, QueryParams
 from api.routers.gcp.embeddings import to_openai_response
 
 def test_to_vertex_embeddings_with_string_input():

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -3,8 +3,6 @@ from typing import Iterable, Literal
 
 from pydantic import BaseModel, Field
 
-from api.setting import DEFAULT_MODEL
-
 
 class Model(BaseModel):
     id: str
@@ -87,7 +85,7 @@ class StreamOptions(BaseModel):
 
 class ChatRequest(BaseModel):
     messages: list[SystemMessage | UserMessage | AssistantMessage | ToolMessage]
-    model: str = DEFAULT_MODEL
+    model: str | None = None
     frequency_penalty: float | None = Field(default=0.0, le=2.0, ge=-2.0)  # Not used
     presence_penalty: float | None = Field(default=0.0, le=2.0, ge=-2.0)  # Not used
     stream: bool | None = False
@@ -154,7 +152,7 @@ class ChatStreamResponse(BaseChatResponse):
 
 class EmbeddingsRequest(BaseModel):
     input: str | list[str] | Iterable[int | Iterable[int]]
-    model: str
+    model: str | None = None
     encoding_format: Literal["float", "base64"] = "float"
     dimensions: int | None = None  # not used.
     user: str | None = None  # not used.
@@ -174,7 +172,7 @@ class EmbeddingsUsage(BaseModel):
 class EmbeddingsResponse(BaseModel):
     object: Literal["list"] = "list"
     data: list[Embedding]
-    model: str
+    model: str | None = None
     usage: EmbeddingsUsage
 
 

--- a/src/api/test_modelmapper.py
+++ b/src/api/test_modelmapper.py
@@ -10,18 +10,23 @@ from api.modelmapper import get_model, load_model_map
 })
 class TestModelMapper(unittest.TestCase):
     def test_get_model_with_existing_model(self):
-        result = get_model("provider1", "model1")
+        result = get_model("provider1", "model1", "fallback_model")
         self.assertEqual(result, "mapped_model1")
 
     @patch("api.modelmapper._model_map", {
         "provider1": {
-            "model1": "mapped_model1"
+            "model1": "mapped_model1",
+            "fallback_model": "fallback_model",
         }
     })
 
     def test_get_model_with_case_insensitivity(self):
-        result = get_model("PROVIDER1", "MODEL1:latest")
+        result = get_model("PROVIDER1", "MODEL1:latest", "fallback_model")
         self.assertEqual(result, "mapped_model1")
+
+    def test_get_model_with_fallback(self):
+        result = get_model("PROVIDER1", None, "fallback_model")
+        self.assertEqual(result, "fallback_model")
 
     @patch("builtins.open", new_callable=mock_open, read_data='{"provider1": {"model1": "mapped_model1"}}')
     @patch("os.path.join", return_value="/mocked/path/modelmap.json")


### PR DESCRIPTION
Make the chat or embedding request to the gateway optional. If it does not exist use chat-default or embedding-default model alias instead. The response will contain the model alias used. 

fixes [#424](https://github.com/DefangLabs/samples/issues/424)
