### PR TITLE
add compose.yaml to easily test gateway deployed to aws or gcp

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,28 @@
+services:
+  gcpgateway:
+    build:
+      context: ./src
+      dockerfile: Dockerfile_ecs
+    ports:
+      - "8080:80"
+    environment:
+      - OPENAI_API_KEY=secret
+      - GCP_PROJECT_ID=my-project-123456
+      - GCP_REGION=us-central1
+      - PORT=80
+    volumes:
+      - ~/.config/gcloud/:/root/.config/gcloud
+  awsgateway:
+    build:
+      context: ./src
+      dockerfile: Dockerfile_ecs
+    ports:
+      - "8081:80"
+    environment:
+      - OPENAI_API_KEY=secret
+      - AWS_REGION=us-west-2
+      - AWS_ACCESS_KEY_ID=your-access-key-id
+      - AWS_SECRET_ACCESS_KEY=your-secret-access-key
+      - PORT=80
+    volumes:
+      - ~/.aws/:/root/.aws


### PR DESCRIPTION
## Description

Setting up a `compose.yaml` file to make it easier to test against simulated aws or gcp deployments

## Linked Issues

<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate tests
- [ ] I have updated the Defang CLI docs and/or README to reflect my changes, if necessary
  